### PR TITLE
build_testbench: Fix mhwaveedit command

### DIFF
--- a/developer_guides/testbench/build_testbench.rst
+++ b/developer_guides/testbench/build_testbench.rst
@@ -115,7 +115,7 @@ it can be launched to an audio editor tool such as mhWaveEdit:
 .. code-block:: bash
 
    paplay audio_out.wav
-   mhWaveEdit audio_out.wav
+   mhwaveedit audio_out.wav
 
 .. figure:: fig_mhwaveedit.png
 


### PR DESCRIPTION
### Description  
This PR corrects the capitalization of the `mhWaveEdit` command.  
The package installs the binary as `mhwaveedit` (all lowercase),  
but the previous command used incorrect capitalization, leading  
to a "command not found" error.  

### Changes  
- Updated `mhWaveEdit` to `mhwaveedit` to match the installed binary.  

### Why this is needed  
- Prevents command not found errors.  
- Ensures consistency with the actual installed binary.  

### Testing  
- Verified that `mhwaveedit audio_out.wav` runs successfully.  
![image](https://github.com/user-attachments/assets/06fa1928-053e-44c9-8f22-53ca34a3fcf6)


### Additional Notes  
- No other changes were made.